### PR TITLE
不要なファイルをコミットしない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ yarn-debug.log*
 .yarn-integrity
 
 /public/uploads/*
+
+# vendor/bundleをリポジトリにcommitしない
+vendor/bundle
+# mysql_dataをリポジトリにcommitしない
+mysql_data
+# nginx/logをリポジトリにコミットしない
+nginx/log


### PR DESCRIPTION
vendor/bundle配下にはbundle installによってgemファイルがインストールされます。必要なGemファイルはGemfile及びGemfile.lockにかかれているので、リポジトリにコミットする必要はありません。
mysql_dataとnginx_logはローカル環境のデータやログが出力されるディレクトリであり、リポジトリでバージョン管理すべきっものではないので、リポジトリにコミットする必要はありません。

これらのファイル・ディレクトリをGit管理から外します